### PR TITLE
Add comments for posts and fights

### DIFF
--- a/backend/controllers/commentController.js
+++ b/backend/controllers/commentController.js
@@ -1,9 +1,7 @@
 const { v4: uuidv4 } = require('uuid');
 
-// @desc    Get comments for a user profile
-// @route   GET /api/comments/:userId
-// @access  Public
-exports.getComments = async (req, res) => {
+// Get comments for a user profile
+exports.getProfileComments = async (req, res) => {
   const db = req.db;
   await db.read();
   if (!db.data.comments) {
@@ -13,10 +11,8 @@ exports.getComments = async (req, res) => {
   res.json(comments);
 };
 
-// @desc    Add a comment to a user profile
-// @route   POST /api/comments/:userId
-// @access  Private
-exports.addComment = async (req, res) => {
+// Add a comment to a user profile
+exports.addProfileComment = async (req, res) => {
   const { text } = req.body;
   const db = req.db;
   await db.read();
@@ -32,6 +28,84 @@ exports.addComment = async (req, res) => {
   const newComment = {
     id: uuidv4(),
     profileId,
+    authorId,
+    authorUsername: author.username,
+    text,
+    timestamp: new Date().toISOString(),
+  };
+
+  db.data.comments.push(newComment);
+  await db.write();
+  res.status(201).json(newComment);
+};
+
+// Get comments for a post
+exports.getPostComments = async (req, res) => {
+  const db = req.db;
+  await db.read();
+  if (!db.data.comments) {
+    db.data.comments = [];
+  }
+  const comments = db.data.comments.filter(c => c.postId === req.params.postId);
+  res.json(comments);
+};
+
+// Add a comment to a post
+exports.addPostComment = async (req, res) => {
+  const { text } = req.body;
+  const db = req.db;
+  await db.read();
+
+  const postId = req.params.postId;
+  const authorId = req.user.id;
+  const author = db.data.users.find(u => u.id === authorId);
+
+  if (!author) {
+    return res.status(404).json({ msg: 'Autor komentarza nie znaleziony' });
+  }
+
+  const newComment = {
+    id: uuidv4(),
+    postId,
+    authorId,
+    authorUsername: author.username,
+    text,
+    timestamp: new Date().toISOString(),
+  };
+
+  db.data.comments.push(newComment);
+  await db.write();
+  res.status(201).json(newComment);
+};
+
+// Get comments for a fight
+exports.getFightComments = async (req, res) => {
+  const db = req.db;
+  await db.read();
+  if (!db.data.comments) {
+    db.data.comments = [];
+  }
+  const comments = db.data.comments.filter(c => c.fightId === req.params.fightId);
+  res.json(comments);
+};
+
+// Add a comment to a fight
+exports.addFightComment = async (req, res) => {
+  const { text } = req.body;
+  const db = req.db;
+  await db.read();
+
+  const fightId = req.params.fightId;
+  const authorId = req.user.id;
+  const author = db.data.users.find(u => u.id === authorId);
+
+  if (!author) {
+    return res.status(404).json({ msg: 'Autor komentarza nie znaleziony' });
+  }
+
+  const newComment = {
+    id: uuidv4(),
+    fightId,
     authorId,
     authorUsername: author.username,
     text,

--- a/backend/db.json
+++ b/backend/db.json
@@ -45,7 +45,16 @@
   ],
   "tournaments": [],
   "posts": [],
-  "comments": [],
+  "comments": [
+    {
+      "id": "example-comment-id",
+      "postId": "example-post-id",
+      "authorId": "example-user-id",
+      "authorUsername": "demo",
+      "text": "Przykładowy komentarz",
+      "timestamp": "2024-01-01T00:00:00.000Z"
+    }
+  ],
   "messages": [],
   "votes": [],
   "notifications": []

--- a/backend/routes/comments.js
+++ b/backend/routes/comments.js
@@ -3,14 +3,16 @@ const router = express.Router();
 const commentController = require('../controllers/commentController');
 const auth = require('../middleware/authMiddleware');
 
-// @route   GET api/comments/:userId
-// @desc    Get comments for a user profile
-// @access  Public
-router.get('/:userId', commentController.getComments);
+// Profile comments
+router.get('/user/:userId', commentController.getProfileComments);
+router.post('/user/:userId', auth, commentController.addProfileComment);
 
-// @route   POST api/comments/:userId
-// @desc    Add a comment to a user profile
-// @access  Private
-router.post('/:userId', auth, commentController.addComment);
+// Post comments
+router.get('/post/:postId', commentController.getPostComments);
+router.post('/post/:postId', auth, commentController.addPostComment);
+
+// Fight comments
+router.get('/fight/:fightId', commentController.getFightComments);
+router.post('/fight/:fightId', auth, commentController.addFightComment);
 
 module.exports = router;

--- a/src/FeedPage.js
+++ b/src/FeedPage.js
@@ -7,6 +7,8 @@ const FeedPage = () => {
   const [posts, setPosts] = useState([]);
   const [newPost, setNewPost] = useState({ title: '', content: '', type: 'discussion', teamA: '', teamB: '' });
   const [notification, setNotification] = useState(null);
+  const [postComments, setPostComments] = useState({});
+  const [newComments, setNewComments] = useState({});
 
   const fetchPosts = async () => {
     try {
@@ -18,9 +20,24 @@ const FeedPage = () => {
     }
   };
 
+  const fetchPostComments = async (postId) => {
+    try {
+      const res = await axios.get(`/api/comments/post/${postId}`);
+      setPostComments(prev => ({ ...prev, [postId]: res.data }));
+    } catch (err) {
+      console.error('Błąd podczas pobierania komentarzy:', err);
+    }
+  };
+
   useEffect(() => {
     fetchPosts();
   }, []);
+
+  useEffect(() => {
+    posts.forEach((p) => {
+      fetchPostComments(p.id);
+    });
+  }, [posts]);
 
   const showNotification = (message, type) => setNotification({ message, type });
   const clearNotification = () => setNotification(null);
@@ -77,6 +94,26 @@ const FeedPage = () => {
     }
   };
 
+  const handleCommentChange = (postId, value) => {
+    setNewComments(prev => ({ ...prev, [postId]: value }));
+  };
+
+  const submitComment = async (postId) => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      showNotification('Musisz być zalogowany, aby dodać komentarz.', 'error');
+      return;
+    }
+    try {
+      await axios.post(`/api/comments/post/${postId}`, { text: newComments[postId] }, { headers: { 'x-auth-token': token } });
+      setNewComments(prev => ({ ...prev, [postId]: '' }));
+      fetchPostComments(postId);
+    } catch (err) {
+      console.error('Błąd podczas dodawania komentarza:', err.response?.data);
+      showNotification(err.response?.data?.msg || 'Błąd dodawania komentarza', 'error');
+    }
+  };
+
   return (
     <div className="feed-page">
       <h1>Tablica</h1>
@@ -114,6 +151,24 @@ const FeedPage = () => {
             )}
             <div className="post-actions">
               <button onClick={() => likePost(post.id)}>Lubię to ({post.likes ? post.likes.length : 0})</button>
+            </div>
+            <div className="comments-section">
+              <form onSubmit={(e) => { e.preventDefault(); submitComment(post.id); }} className="add-comment-form">
+                <input
+                  type="text"
+                  value={newComments[post.id] || ''}
+                  onChange={(e) => handleCommentChange(post.id, e.target.value)}
+                  placeholder="Dodaj komentarz"
+                />
+                <button type="submit">Wyślij</button>
+              </form>
+              <div className="comments-list">
+                {(postComments[post.id] || []).map((c) => (
+                  <div key={c.id} className="comment-item">
+                    <strong>{c.authorUsername}</strong>: {c.text}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         ))}

--- a/src/FightRow.js
+++ b/src/FightRow.js
@@ -1,7 +1,37 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import './FightRow.css';
 
 const FightRow = ({ fight }) => {
+  const [comments, setComments] = useState([]);
+  const [newComment, setNewComment] = useState('');
+
+  const fetchComments = async () => {
+    try {
+      const res = await axios.get(`/api/comments/fight/${fight.id}`);
+      setComments(res.data);
+    } catch (err) {
+      console.error('Błąd podczas pobierania komentarzy:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchComments();
+  }, []);
+
+  const submitComment = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    try {
+      await axios.post(`/api/comments/fight/${fight.id}`, { text: newComment }, { headers: { 'x-auth-token': token } });
+      setNewComment('');
+      fetchComments();
+    } catch (err) {
+      console.error('Błąd podczas dodawania komentarza:', err);
+    }
+  };
+
   return (
     <div className="fight-row">
       <div className="fighter-block user1-block">
@@ -16,6 +46,24 @@ const FightRow = ({ fight }) => {
         <div className="fighter-name">{fight.fighter2}</div>
         <div className="record">Rekord: {fight.user2Record} (Ogólny: {fight.overallRecord2})</div>
         <div className="fighter-image placeholder"></div>
+      </div>
+      <div className="fight-comments">
+        <form onSubmit={submitComment} className="add-comment-form">
+          <input
+            type="text"
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+            placeholder="Dodaj komentarz"
+          />
+          <button type="submit">Wyślij</button>
+        </form>
+        <div className="comments-list">
+          {comments.map((c) => (
+            <div key={c.id} className="comment-item">
+              <strong>{c.authorUsername}</strong>: {c.text}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/ProfilePage.js
+++ b/src/ProfilePage.js
@@ -35,7 +35,7 @@ const ProfilePage = () => {
 
   const fetchComments = async (id) => {
     try {
-      const res = await axios.get(`/api/comments/${id}`);
+      const res = await axios.get(`/api/comments/user/${id}`);
       setComments(res.data);
     } catch (err) {
       console.error('Błąd podczas pobierania komentarzy:', err);
@@ -50,7 +50,7 @@ const ProfilePage = () => {
       return;
     }
     try {
-      await axios.post(`/api/comments/${userId}`, { text: newComment }, {
+      await axios.post(`/api/comments/user/${userId}`, { text: newComment }, {
         headers: {
           'x-auth-token': token,
         },


### PR DESCRIPTION
## Summary
- extend comment controller to support post and fight comment types
- update comment routes for user, post and fight comment endpoints
- adapt frontend to show and add comments on posts and fights
- update profile page to use new comment endpoints
- document comment structure in `db.json`

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_686750f145908327b2aeb003d1436eb9