### PR TITLE
Rename message timestamp to createdAt

### DIFF
--- a/backend/controllers/messageController.js
+++ b/backend/controllers/messageController.js
@@ -40,7 +40,7 @@ exports.sendMessage = async (req, res) => {
     toUsername: receiver.username,
     subject,
     body,
-    timestamp: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
     read: false,
   };
 

--- a/backend/db.json
+++ b/backend/db.json
@@ -52,7 +52,7 @@
       "authorId": "example-user-id",
       "authorUsername": "demo",
       "text": "Przykładowy komentarz",
-      "timestamp": "2024-01-01T00:00:00.000Z"
+      "createdAt": "2024-01-01T00:00:00.000Z"
     }
   ],
   "messages": [],


### PR DESCRIPTION
## Summary
- rename timestamp to createdAt when creating messages
- update existing timestamp fields in db

## Testing
- `npm test --silent` *(fails: react-scripts not found / stuck in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68675381f19483279ddce2aa150077b1