### PR TITLE
Add rank calculation from victories

### DIFF
--- a/backend/controllers/fightController.js
+++ b/backend/controllers/fightController.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require('uuid');
+const { calculateRank } = require('./profileController');
 
 // @desc    Get all fights
 // @route   GET /api/fights
@@ -87,6 +88,7 @@ exports.updateFight = async (req, res) => {
         winner.stats = winner.stats || {};
         winner.stats.fightsWon = (winner.stats.fightsWon || 0) + 1;
         updateDerivedStats(winner);
+        winner.stats.rank = calculateRank(winner.stats.fightsWon || 0);
       }
 
       if (loser) {

--- a/backend/controllers/profileController.js
+++ b/backend/controllers/profileController.js
@@ -1,14 +1,12 @@
 const { v4: uuidv4 } = require('uuid');
 
-const getRank = (points) => {
-  if (points >= 300) {
-    return 'Mistrz';
-  } else if (points >= 100) {
-    return 'Wojownik';
-  } else {
-    return 'Początkujący';
-  }
+const calculateRank = victories => {
+  const rawRank = Math.floor((Math.sqrt(8 * victories + 1) - 1) / 2);
+  if (rawRank < 1) return 1;
+  if (rawRank > 100) return 100;
+  return rawRank;
 };
+exports.calculateRank = calculateRank;
 
 // @desc    Get user profile
 // @route   GET /api/profile/:userId
@@ -32,7 +30,7 @@ exports.getProfile = async (req, res) => {
     characters: db.data.characters.filter(c => c.ownerId === user.id),
     fights: db.data.fights.filter(f => f.user1 === user.id || f.user2 === user.id),
     points: user.points || 0,
-    rank: getRank(user.points || 0),
+    rank: calculateRank(user.stats?.fightsWon || 0),
   });
 };
 
@@ -107,7 +105,7 @@ exports.getLeaderboard = async (req, res) => {
       username: user.username,
       points: user.points || 0,
       profilePicture: user.profilePicture || '',
-      rank: getRank(user.points || 0),
+      rank: calculateRank(user.stats?.fightsWon || 0),
     }))
     .sort((a, b) => b.points - a.points); // Sortuj malejąco według punktów
 


### PR DESCRIPTION
## Summary
- convert old point-based rank logic to `calculateRank` helper
- show user rank based on fight wins in profile endpoints
- require `calculateRank` in fight controller and recalc after wins update

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68675c85a39c83279118e088ef332ef3