### PR TITLE
Limit character selection count

### DIFF
--- a/backend/controllers/profileController.js
+++ b/backend/controllers/profileController.js
@@ -61,6 +61,10 @@ exports.updateProfile = async (req, res) => {
     return res.status(404).json({ msg: 'Użytkownik nie znaleziony' });
   }
 
+  if (selectedCharacters && selectedCharacters.length > 2) {
+    return res.status(400).json({ msg: 'Można wybrać maksymalnie dwie postacie' });
+  }
+
   db.data.users[userIndex].description = description || db.data.users[userIndex].description;
   db.data.users[userIndex].profilePicture = profilePicture || db.data.users[userIndex].profilePicture;
   db.data.users[userIndex].selectedCharacters = selectedCharacters || db.data.users[userIndex].selectedCharacters;

--- a/src/CharacterSelectionPage.js
+++ b/src/CharacterSelectionPage.js
@@ -46,6 +46,10 @@ const CharacterSelectionPage = () => {
     if (selectedCharacters.includes(charId)) {
       setSelectedCharacters(selectedCharacters.filter(id => id !== charId));
     } else {
+      if (selectedCharacters.length >= 2) {
+        showNotification('Możesz wybrać maksymalnie dwie postacie.', 'error');
+        return;
+      }
       setSelectedCharacters([...selectedCharacters, charId]);
     }
   };


### PR DESCRIPTION
## Summary
- enforce a 2 character limit on backend profile updates
- prevent the UI from selecting more than two characters at once and show a notification

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68675e0b04ac8327881080a711aea258