### PR TITLE
Update moderator credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
    ```
 
 
+## Default Moderator Login
+
+A moderator account is preloaded in `backend/db.json`.
+
+- **Username:** `moderator`
+- **Email:** `moderator@site.local`
+- **Password:** `mod1234`
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/backend/db.json
+++ b/backend/db.json
@@ -24,7 +24,7 @@
       "id": "MODERATOR-UNIQUE-ID-1234",
       "username": "moderator",
       "email": "moderator@site.local",
-      "password": "$2b$10$MODERATORHASHEDPASSWORDHERE",
+      "password": "$2b$10$NqGZhS6ZpY6sSpPXeoXjSu83sPK.VXvmfFR0yFhWAl8e3JaU7m1E6",
       "role": "moderator",
       "profile": {
         "avatar": "/public/logo192.png",


### PR DESCRIPTION
## Summary
- hash the moderator password in `db.json`
- document the default moderator login credentials

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867610dec5c8327a50ab347cc2fadb3