### PR TITLE
Add automatic fight creation

### DIFF
--- a/backend/routes/fights.js
+++ b/backend/routes/fights.js
@@ -14,6 +14,16 @@ router.get('/', fightController.getFights);
 // @access  Private (Moderator)
 router.post('/', auth, authorize(['moderator', 'admin']), fightController.createFight);
 
+// @route   GET api/fights/pairs
+// @desc    Get available player pairs
+// @access  Private (Moderator)
+router.get('/pairs', auth, authorize(['moderator', 'admin']), fightController.getPlayerPairs);
+
+// @route   POST api/fights/auto
+// @desc    Create fight from selected characters
+// @access  Private (Moderator)
+router.post('/auto', auth, authorize(['moderator', 'admin']), fightController.createFightFromSelections);
+
 // @route   PUT api/fights/:id
 // @desc    Update a fight
 // @access  Private (Moderator)

--- a/src/ModeratorPanel.css
+++ b/src/ModeratorPanel.css
@@ -82,3 +82,33 @@
 .fight-item-moderator .delete-btn:hover {
   background-color: #c82333;
 }
+
+.pair-list {
+  list-style: none;
+  padding: 0;
+  max-width: 800px;
+  margin: 20px auto;
+}
+
+.pair-list li {
+  background-color: #222;
+  margin-bottom: 10px;
+  padding: 10px 15px;
+  border-radius: 5px;
+}
+
+.generate-btn {
+  display: block;
+  margin: 0 auto 40px auto;
+  padding: 12px 20px;
+  background-color: #e67e22;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.generate-btn:hover {
+  background-color: #d35400;
+}


### PR DESCRIPTION
## Summary
- enable moderators to generate fights using selected characters
- provide player pair lookup endpoint
- show available pairs in Moderator Panel with auto-match option

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_686762fcf3a0832785d943e6cc0fcc3e