### PR TITLE
Fix profile route precedence

### DIFF
--- a/backend/routes/profile.js
+++ b/backend/routes/profile.js
@@ -3,10 +3,6 @@ const router = express.Router();
 const profileController = require('../controllers/profileController');
 const auth = require('../middleware/authMiddleware');
 
-// @route   GET api/profile/:userId
-// @desc    Get user profile by ID
-// @access  Public
-router.get('/:userId', profileController.getProfile);
 
 // @route   GET api/profile/all
 // @desc    Get all user profiles (public data)
@@ -27,5 +23,10 @@ router.get('/search', profileController.searchProfiles);
 // @desc    Get user leaderboard
 // @access  Public
 router.get('/leaderboard', profileController.getLeaderboard);
+
+// @route   GET api/profile/:userId
+// @desc    Get user profile by ID
+// @access  Public
+router.get('/:userId', profileController.getProfile);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- reorder API routes in `backend/routes/profile.js` so that specific endpoints are checked before the `/:userId` catch-all

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6867f93f3d388327bf0dd5c76aadaeaf